### PR TITLE
Allow to specify custom execPath in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ executable.
 * `cwd`: the working directory for the child process. This can be used to put
 files that the test creates or reads from the working directory in a specific
 directory, instead of the directory where you are running gulp from.
+* `execPath`: an alternative execution path to the Node.js instance.
+If not specified, by default, [child_process::fork][fork] will spawn the new
+Node.js instances using the [process::execPath][execPath] of the parent process.
 
 All other options are properly prefixed with either `-` or `--` and passed to
 the `mocha` executable. Any arguments which do not take a value (e.g., `c`,
@@ -266,6 +269,7 @@ you should use this plugin.
 [gulp]: http://gulpjs.com/ "gulp.js"
 [mocha]: http://mochajs.org/ "Mocha"
 [fork]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options "child_process::fork"
+[execPath]: https://nodejs.org/api/process.html#process_process_execpath "process::execPath"
 [Istanbul]: https://github.com/gotwarlost/istanbul "Istanbul"
 [Travis]: https://travis-ci.org/ "Travis CI"
 [coveralls]: https://coveralls.io/ "Coveralls"

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,8 @@ module.exports = function (ops, coverage) {
   var bin = ops.bin || join(require.resolve('mocha'), '..', 'bin', ist ? '_mocha' : 'mocha');
   var env = _.extend(_.clone(process.env), ops.env || {});
   var cwd = ops.cwd;
-  ops = _.omit(ops, ['bin', 'env', 'istanbul', 'cwd']);
+  var execPath = ops.execPath || process.execPath;
+  ops = _.omit(ops, ['bin', 'env', 'istanbul', 'cwd', 'execPath']);
 
   // Create stream
   var stream = through(function (file) {
@@ -46,7 +47,7 @@ module.exports = function (ops, coverage) {
       args.unshift('cover');
     }
     // Execute Mocha, stdin and stdout are inherited
-    this._child = proc.fork(bin, args.concat(this._files), {cwd: cwd, env: env, silent: !!output});
+    this._child = proc.fork(bin, args.concat(this._files), {cwd: cwd, env: env, execPath: execPath, silent: !!output});
     // If there's an error running the process. See http://nodejs.org/api/child_process.html#child_process_event_error
     this._child.on('error', function (e) {
       that.emit('error', new PluginError('gulp-spawn-mocha', e));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -43,7 +43,7 @@ describe('gulp-spawn-mocha tests', function () {
       var bin = join(require.resolve('mocha'), '..', 'bin', 'mocha');
       var stream = this.stream = mocha();
       stream.end();
-      proc.fork.should.be.calledWith(bin, []);
+      proc.fork.should.be.calledWith(bin, [], sinon.match({execPath: process.execPath}));
     });
 
     it('should allow for a custom mocha binary', function () {
@@ -62,6 +62,12 @@ describe('gulp-spawn-mocha tests', function () {
       var stream = this.stream = mocha({cwd: './tmp'});
       stream.end();
       proc.fork.should.be.calledWith(sinon.match.any, sinon.match.any, sinon.match({cwd: './tmp'}));
+    });
+
+    it('should allow for a custom execPath', function () {
+      var stream = this.stream = mocha({execPath: '/foo/bar'});
+      stream.end();
+      proc.fork.should.be.calledWith(sinon.match.any, sinon.match.any, sinon.match({execPath: '/foo/bar'}));
     });
 
     it('should pass arguments to mocha, properly prefixing, dashifying, and ignoring', function () {


### PR DESCRIPTION
Add execPath option support. The main scenario is to be able to run mocha tests on a different version of Node.js than the one running gulp.