### PR TITLE
fix(npm): instanbul false shrinkwrap fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "through": "~2.3.4"
   },
   "peerDependencies": {
-    "mocha": "^3.0.0",
+    "mocha": "^3.0.0"
+  },
+  "optionalDependencies": {
     "istanbul": "^0.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
when istanbul is set to false (using nyc for example) npm shrinkwrap will fail due to
peerDependencies