### PR TITLE
check if there are file to test

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,9 @@ module.exports = function (ops, coverage) {
   var stream = through(function (file) {
     this._files.push(file.path);
   }, function () {
+    // make sure there are files to test
+    if (this._files.length === 0) return;
+
     // Save refernce to this (bindless context cheat)
     var that = this;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,9 +19,6 @@ describe('gulp-spawn-mocha tests', function () {
   });
 
   afterEach(function () {
-    // Common assertions
-    proc.fork.should.be.calledOnce;
-    proc.fork.should.be.calledWith(sinon.match.string, sinon.match.array);
     // Restore fork functionality
     proc.fork.restore();
   });
@@ -42,44 +39,51 @@ describe('gulp-spawn-mocha tests', function () {
     it('should default to proper binary', function () {
       var bin = join(require.resolve('mocha'), '..', 'bin', 'mocha');
       var stream = this.stream = mocha();
+      stream.write({path: 'foo'});
       stream.end();
-      proc.fork.should.be.calledWith(bin, [], sinon.match({execPath: process.execPath}));
+      proc.fork.should.be.calledWith(bin, ['foo'], sinon.match({execPath: process.execPath}));
     });
 
     it('should allow for a custom mocha binary', function () {
       var stream = this.stream = mocha({bin: 'foo mocha'});
+      stream.write({path: 'foo'});
       stream.end();
-      proc.fork.should.be.calledWith('foo mocha', []);
+      proc.fork.should.be.calledWith('foo mocha', ['foo']);
     });
 
     it('should allow for a custom environment', function () {
       var stream = this.stream = mocha({env: {'FOO' : 'BAR'}});
+      stream.write({path: 'foo'});
       stream.end();
       proc.fork.should.be.calledWith(sinon.match.any, sinon.match.any, sinon.match({env: {'FOO' : 'BAR'}}));
     });
 
     it('should allow for a custom working directory', function () {
       var stream = this.stream = mocha({cwd: './tmp'});
+      stream.write({path: 'foo'});
       stream.end();
       proc.fork.should.be.calledWith(sinon.match.any, sinon.match.any, sinon.match({cwd: './tmp'}));
     });
 
     it('should allow for a custom execPath', function () {
       var stream = this.stream = mocha({execPath: '/foo/bar'});
+      stream.write({path: 'foo'});
       stream.end();
       proc.fork.should.be.calledWith(sinon.match.any, sinon.match.any, sinon.match({execPath: '/foo/bar'}));
     });
 
     it('should pass arguments to mocha, properly prefixing, dashifying, and ignoring', function () {
       var stream = this.stream = mocha({foo: 'bar', b: ['oof', 'rab'], debugBrk: true, isAString: true, R: 'spec', S: true, T: false, U: null, V: undefined});
+      stream.write({path: 'foo'});
       stream.end();
-      proc.fork.should.be.calledWith(sinon.match.string, ['--foo', 'bar', '-b', 'oof', '-b', 'rab', '--debug-brk', '--is-a-string', '-R', 'spec', '-S']);
+      proc.fork.should.be.calledWith(sinon.match.string, ['--foo', 'bar', '-b', 'oof', '-b', 'rab', '--debug-brk', '--is-a-string', '-R', 'spec', '-S', 'foo']);
     });
 
     it('should handle non-errors from mocha', function () {
       this.childOn.withArgs('close').yields(0);
       var stream = this.stream = mocha();
       sinon.spy(stream, 'emit');
+      stream.write({path: 'foo'});
       stream.end();
       this.childOn.should.be.calledTwice;
       stream.emit.should.be.calledWith('end');
@@ -90,6 +94,7 @@ describe('gulp-spawn-mocha tests', function () {
       var stream = this.stream = mocha();
       sinon.stub(stream, 'emit');
       stream.emit.withArgs('error').returns();
+      stream.write({path: 'foo'});
       stream.end();
       this.childOn.should.be.calledTwice;
       stream.emit.should.be.calledWith('error', sinon.match.instanceOf(PluginError));
@@ -99,6 +104,7 @@ describe('gulp-spawn-mocha tests', function () {
       var fakeStream = {};
       sinon.stub(fs, 'createWriteStream').returns(fakeStream);
       var stream = this.stream = mocha({output: 'result.log'});
+      stream.write({path: 'foo'});
       stream.end();
       fs.createWriteStream.should.be.calledWith('result.log');
       fs.createWriteStream.restore();
@@ -109,10 +115,18 @@ describe('gulp-spawn-mocha tests', function () {
     it('can output to a writable stream', function () {
       var fakeStream = {};
       var stream = this.stream = mocha({output: fakeStream});
+      stream.write({path: 'foo'});
       stream.end();
       this.childOut.pipe.should.be.calledWith(fakeStream);
       this.childErr.pipe.should.be.calledWith(fakeStream);
     });
+
+    it('dont fork if no file to test', function () {
+      var stream = this.stream = mocha();
+      stream.end();
+      proc.fork.should.have.not.been.called;
+    });
+
   });
 
   describe('istanbul functionality', function () {
@@ -121,20 +135,23 @@ describe('gulp-spawn-mocha tests', function () {
 
     it('should properly call istanbul with no arguments', function () {
       var stream = this.stream = mocha({istanbul: true});
+      stream.write({path: 'foo'});
       stream.end();
-      proc.fork.should.be.calledWith(bin, ['cover', '--', mbin]);
+      proc.fork.should.be.calledWith(bin, ['cover', '--', mbin, 'foo']);
     });
 
     it('should properly call istanbul with one more more arguments', function () {
       var stream = this.stream = mocha({istanbul: {verbose: true, print: 'detail'}});
+      stream.write({path: 'foo'});
       stream.end();
-      proc.fork.should.be.calledWith(bin, ['cover', '--verbose', '--print', 'detail', '--', mbin]);
+      proc.fork.should.be.calledWith(bin, ['cover', '--verbose', '--print', 'detail', '--', mbin, 'foo']);
     });
 
     it('can use a custom binary', function () {
       var stream = this.stream = mocha({istanbul: {bin: 'isparta'}});
+      stream.write({path: 'foo'});
       stream.end();
-      proc.fork.should.be.calledWith('isparta', ['cover', '--', mbin]);
+      proc.fork.should.be.calledWith('isparta', ['cover', '--', mbin, 'foo']);
     });
   });
 });


### PR DESCRIPTION
Hi, on current implementation this plugin will cause the task to fail when there is no file to test.

it's possible for someone to create test task like `gulp.src('./test/*.js').pipe(mocha())`, but without any test file yet.

running mocha executable file without test file will result to exit code 1