### PR TITLE
Close the stream properly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,10 @@ module.exports = function (ops, coverage) {
     this._files.push(file.path);
   }, function () {
     // make sure there are files to test
-    if (this._files.length === 0) return;
+    if (this._files.length === 0) {
+      this.emit('end');
+      return;
+    };
 
     // Save refernce to this (bindless context cheat)
     var that = this;
@@ -54,6 +57,7 @@ module.exports = function (ops, coverage) {
     // If there's an error running the process. See http://nodejs.org/api/child_process.html#child_process_event_error
     this._child.on('error', function (e) {
       that.emit('error', new PluginError('gulp-spawn-mocha', e));
+      that.emit('end');
     });
     // When done...
     this._child.on('close', function (code) {


### PR DESCRIPTION
Hi, I just realized that I made a minor mistake on #46, I forgot to close the stream.
I also add `emit('end')` on `error` callback, so the stream will also be closed when error occurs
sorry for the inconvenience.