### PR TITLE
Fix argv leaking for that breaks debugging ports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ module.exports = function (ops, coverage) {
       args.unshift('cover');
     }
     // Execute Mocha, stdin and stdout are inherited
-    this._child = proc.fork(bin, args.concat(this._files), {cwd: cwd, env: env, execPath: execPath, silent: !!output});
+    this._child = proc.fork(bin, args.concat(this._files), {cwd: cwd, env: env, execPath: execPath, silent: !!output, execArgv: []});
     // If there's an error running the process. See http://nodejs.org/api/child_process.html#child_process_event_error
     this._child.on('error', function (e) {
       that.emit('error', new PluginError('gulp-spawn-mocha', e));


### PR DESCRIPTION
#53 
- Ensure that no args are leaked, only the specified args are used.